### PR TITLE
Use deploy workflow only from tag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,14 +3,6 @@ name: Deploy site and create release
 on:
   workflow_dispatch:
     inputs:
-      commit:
-        description: 'Commit/branch to deploy (e.g. main or a SHA).'
-        required: true
-        type: string
-      tag:
-        description: 'Tag for the release (e.g. v1.2.3). Created if it does not exist.'
-        required: true
-        type: string
       release_name:
         description: 'Name of the release without the tag. Results in "<tag> <release_name>" or "<tag>".'
         required: false
@@ -28,13 +20,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+
+  # Only allow deployment from a semver tag
+  check-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if ref is a semver tag
+        id: check_tag
+        run: |
+          if [[ "${GITHUB_REF}" =~ ^refs/tags/v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Semver tag detected: ${GITHUB_REF}"
+          else
+            echo "This workflow can only be run from a semver tag (e.g., v1.2.3 or 1.2.3)."
+            exit 1
+          fi
+
   build:
     runs-on: ubuntu-latest
+    needs: check-tag
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.commit }}
       - name: Setup Ruby
         # https://github.com/ruby/setup-ruby/releases/tag/v1.207.0
         uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4
@@ -75,8 +81,6 @@ jobs:
         id: create_release
         uses: ncipollo/release-action@v1
         with:
-          commit: ${{ github.event.inputs.commit }}
-          tag: ${{ github.event.inputs.tag }}
-          name: ${{ github.event.inputs.release_name && format('{0} {1}', github.event.inputs.tag, github.event.inputs.release_name) || github.event.inputs.tag }}
+          name: ${{ github.event.inputs.release_name && format('{0} {1}', github.ref_name, github.event.inputs.release_name) || github.ref_name }}
           discussionCategory: "Releases"
           generateReleaseNotes: true


### PR DESCRIPTION
## Summary
Only allow the CI workflow to work as dispatch from a valid semVer tag.

## Related issue
No issue

## Checklist
- [ ] I updated documentation (README / docs) if needed
- [ ] This change is backwards compatible (or explain breaking changes)

## Notes for reviewers
No notes.