### PR TITLE
Homebrew support: traits

### DIFF
--- a/src/features/homebrew/editor/components/forms/TraitForm.js
+++ b/src/features/homebrew/editor/components/forms/TraitForm.js
@@ -1,0 +1,92 @@
+import { Language } from "../../../../../types/api/resources/Language.js";
+import { Proficiency } from "../../../../../types/api/resources/Proficiency.js";
+import { Trait } from "../../../../../types/api/resources/Trait.js";
+import { getTextareaSection } from "../../services/FormElementsBuilder.js";
+import { HomebrewBaseForm } from "../forms/HomebrewBaseForm.js";
+import { ChoiceSection } from "../sections/ChoiceSection.js";
+import { LinkedObjectsSection } from "../sections/LinkedObjectsSection.js";
+
+/**
+ * Form for editing custom homebrew Trait objects.
+ */
+export class TraitForm extends HomebrewBaseForm {
+
+    /**
+     * Creates an instance of TraitForm.
+     * @param {Trait} traitObject
+     */
+    constructor(traitObject) {
+        super(traitObject);
+        
+        /** @type {Trait} */
+        this.trait = traitObject;
+    }
+
+    /**
+     * Initializes the form by appending the form body.
+     * This method is called when the element is connected to the DOM.
+     * @returns {Promise<void>}
+     */
+    async connectedCallback() {
+        this.appendChild(await this.getFormBody());
+
+        super.connectedCallback();
+    }
+
+    /**
+     * Creates the body of the form with all necessary sections.
+     * @returns {Promise<DocumentFragment>} A fragment containing all the sections of the form.
+     */
+    async getFormBody() {
+        const fragment = document.createDocumentFragment();
+
+        this.descriptionSection = getTextareaSection("Description", 'desc', this.trait.desc, "Description of the trait.", true)
+        fragment.appendChild(this.descriptionSection);
+
+        this.proficienciesSection = new LinkedObjectsSection(
+            "Proficiencies",
+            (await Proficiency.getAllAsync()),
+            this.trait.proficiencies,
+            "List of proficiencies that this trait provides."
+        );
+        fragment.appendChild(this.proficienciesSection);
+
+        this.proficiencyChoicesSection = new ChoiceSection(
+            "Proficiency choices",
+            (await Proficiency.getAllAsync()),
+            this.trait.proficiency_choices,
+            "If applicable, a choice in proficiencies that the player can make when getting this trait."
+        );
+        fragment.appendChild(this.proficiencyChoicesSection);
+
+        this.languageOptionsSection = new ChoiceSection(
+            "Language options",
+            (await Language.getAllAsync()),
+            this.trait.language_options,
+            "If applicable, a choice in languages that the player can make when getting this trait."
+        );
+        fragment.appendChild(this.languageOptionsSection);
+
+        // Races?
+        // Subraces?
+
+        return fragment;
+    }
+
+    /**
+     * @override Trait specific properties.
+     */
+    async getFormDataAsync() {
+    
+        const data = new Trait(await super.getFormDataAsync());
+
+        data.desc = this.descriptionSection.getElementsByTagName('textarea')[0].value.split('\n').map(p => p.trim()).filter(p => p.length > 0);
+        data.proficiencies = this.proficienciesSection.getValue();
+        data.proficiency_choices = this.proficiencyChoicesSection.getValue();
+        data.language_options = this.languageOptionsSection.getValue();
+
+        return data;
+    }
+}
+
+customElements.define('trait-form', TraitForm, { extends: 'form' });

--- a/src/features/homebrew/editor/components/forms/TraitForm.js
+++ b/src/features/homebrew/editor/components/forms/TraitForm.js
@@ -67,9 +67,6 @@ export class TraitForm extends HomebrewBaseForm {
         );
         fragment.appendChild(this.languageOptionsSection);
 
-        // Races?
-        // Subraces?
-
         return fragment;
     }
 

--- a/src/features/homebrew/editor/components/sections/LinkedObjectsSection.js
+++ b/src/features/homebrew/editor/components/sections/LinkedObjectsSection.js
@@ -69,7 +69,7 @@ export class LinkedObjectsSection extends HTMLElement {
 
     /**
      * Gets the form data from the linked objects section.
-     * @returns {ObjectSelect[]} An array of ObjectSelect objects containing the selected values.
+     * @returns {ApiObjectInfo[]} An array of ApiObjectInfo objects containing the selected values.
      */
     getValue() {
         /** @type {ObjectSelect[]} */

--- a/src/features/homebrew/editor/load-form.js
+++ b/src/features/homebrew/editor/load-form.js
@@ -1,6 +1,7 @@
 import { ApiCategory } from "../../../services/api.js";
 import { globals } from "../../../store/load-globals.js";
 import { RaceForm } from "./components/forms/RaceForm.js";
+import { TraitForm } from "./components/forms/TraitForm.js";
 
 // This file is used to load the homebrew form based on the active homebrew entry.
 // It checks the apiCategoryName of the active homebrew entry and loads the appropriate form.
@@ -8,6 +9,16 @@ import { RaceForm } from "./components/forms/RaceForm.js";
 
 const pageContent = document.getElementsByClassName("post-content")[0];
 
-if (globals.activeHomebrewEntry.apiCategoryName === ApiCategory.Races.name) {
-    pageContent.appendChild(new RaceForm(globals.activeHomebrewEntry.homebrewObject));
+let form;
+switch (globals.activeHomebrewEntry.apiCategoryName) {
+    case ApiCategory.Races.name:
+        form = new RaceForm(globals.activeHomebrewEntry.homebrewObject);
+        break;
+    case ApiCategory.Traits.name:
+        form = new TraitForm(globals.activeHomebrewEntry.homebrewObject);
+        break;
+    default:
+        throw new Error(`No form available for API category ${globals.activeHomebrewEntry.apiCategoryName}`);
 }
+
+pageContent.appendChild(form);

--- a/src/features/homebrew/manager/components/selects/HomebrewTypeSelect.js
+++ b/src/features/homebrew/manager/components/selects/HomebrewTypeSelect.js
@@ -49,6 +49,7 @@ export class HomebrewTypeSelect extends HTMLSelectElement {
         const fragment = document.createDocumentFragment();
 
         fragment.appendChild(this.getTypeSelectOption(ApiCategory.Races));
+        fragment.appendChild(this.getTypeSelectOption(ApiCategory.Traits));
 
         return fragment;
     }

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -44,6 +44,7 @@ export class ApiCategory {
     getSingularName() {
         switch (this.name) {
             case "races": return "Race";
+            case "traits": return "Trait";
             default: return null;
         }
     }

--- a/src/store/HomebrewBank.js
+++ b/src/store/HomebrewBank.js
@@ -1,6 +1,7 @@
 import { ApiCategory } from "../services/api.js";
 import { ApiObjectInfo } from "../types/api/resources/ApiObjectInfo.js";
 import { Race } from "../types/api/resources/Race.js";
+import { Trait } from "../types/api/resources/Trait.js";
 
 /**
  * Key used for saving and loading the homebrew bank from localStorage.
@@ -240,6 +241,7 @@ export class HomebrewBankEntry {
     #getHomebrewObject() {
         switch (this.apiCategoryName) {
             case ApiCategory.Races.name: return new Race(this.homebrewObject);
+            case ApiCategory.Traits.name: return new Trait(this.homebrewObject);
             default: return new ApiObjectInfo(this.homebrewObject);
         }
     }

--- a/src/types/api/resources/Trait.js
+++ b/src/types/api/resources/Trait.js
@@ -1,4 +1,5 @@
 import { ApiCategory } from "../../../services/api.js";
+import { Choice } from "../helpers/Choice.js";
 import { ApiBaseObject } from "./ApiBaseObject.js";
 import { ApiObjectInfo } from "./ApiObjectInfo.js";
 
@@ -11,37 +12,37 @@ export class Trait extends ApiBaseObject {
      * Can consist of multiple paragraphs.
      * @type {string[]}
      */
-    desc;
+    desc = [];
 
     /**
      * List of races that get this trait.
      * @type {ApiObjectInfo[]}
      */
-    races;
+    races = [];
 
     /**
      * List of subraces that get this trait.
      * @type {ApiObjectInfo[]}
      */
-    subraces;
+    subraces = [];
 
     /**
      * List of proficiencies that this trait provides.
      * @type {ApiObjectInfo[]}
      */
-    proficiencies;
+    proficiencies = [];
 
     /**
      * If applicable, a choice in proficiencies that the player can make when getting this trait.
      * @type {Choice}
      */
-    proficiency_choices;
+    proficiency_choices = new Choice();
 
     /**
      * If applicable, a choice in languages that the player can make when getting this trait.
      * @type {Choice}
      */
-    language_options;
+    language_options = new Choice();
 
     /**
      * Any extra trait-specific information.


### PR DESCRIPTION
## Summary
Adds homebrew support for traits. This allows users to manage custom traits to link to custom races.

## Related issue
Closes #26

## Checklist
- [ ] I updated documentation (README / docs) if needed
- [ ] This change is backwards compatible (or explain breaking changes)

## Notes for reviewers
No notes.