### PR TITLE
build(typescript migration): remove allowJs in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
     "module": "es6",
     "target": "es2017",
     "outDir": "./build",
-    "allowJs": true,
     "strict": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,


### PR DESCRIPTION
## Summary
Last step op de TypeScript migration. Makes sure javascript cannot be imported in src filea anymore.

## Related issue
Closes #36 

## Checklist
- [x] I updated documentation (README / docs) if needed
- [x] This change is backwards compatible (or explain breaking changes)

## Notes for reviewers
JS is still allowed and commit-able in the repo. Maybe we'll add linting rules later that straight up ban `.js` files from existing on `main`.