### PR TITLE
ci: make creating a release on deploy optional

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,11 @@ name: Deploy site and create release
 on:
   workflow_dispatch:
     inputs:
+      should_create_release:
+        description: 'Whether a new GitHub release should be created for this deployment.'
+        required: true
+        type: boolean
+        default: true
       release_name:
         description: 'Name of the release without the tag. Results in "<tag> <release_name>" or "<tag>".'
         required: false
@@ -87,6 +92,7 @@ jobs:
   create-release:
     runs-on: ubuntu-latest
     needs: deploy
+    if: ${{ github.event.inputs.should_create_release == true }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
This is useful because we can test deployments without committing to a release and we can easily go back to previous deployments if any should fail without messing up the release order.

## Related issue
No related issue.

## Checklist
- [x] I updated documentation (README / docs) if needed
- [x] This change is backwards compatible (or explain breaking changes)

## Notes for reviewers
No notes.