### PR TITLE
fix: null reference error when getting all traits of a race

### DIFF
--- a/src/repositories/TraitRepository.ts
+++ b/src/repositories/TraitRepository.ts
@@ -61,7 +61,7 @@ export class TraitRepository
 	 * @inheritdoc
 	 */
 	public async getAllTraitsByRaceAsync(raceId: string): Promise<ResourceList> {
-		const homebrewRace = this.homebrewRepository.get<RaceRecord>(raceId)!;
+		const homebrewRace = this.homebrewRepository.get<RaceRecord>(raceId);
 		const homebrewTraits = homebrewRace?.traits ?? [];
 
 		const endpoint = `races/${raceId}/traits`;


### PR DESCRIPTION
## Summary

Fixes a null reference error when loading the PC page while using a non-homebrew race.

## Related issue

No related issue.

## Checklist

- [x] I updated documentation (README / docs) if needed
- [x] This change is backwards compatible (or explain breaking changes)

## Notes for reviewers
No notes.
