### PR TITLE
refactor: homebrew object versioning

### DIFF
--- a/src/features/homebrew/editor/components/forms/HomebrewBaseForm.ts
+++ b/src/features/homebrew/editor/components/forms/HomebrewBaseForm.ts
@@ -79,6 +79,7 @@ export class HomebrewBaseForm extends HTMLFormElement {
 		const oldResource = homebrewRepository.get(id)!;
 
 		return Promise.resolve({
+			version: oldResource.version,
 			id: oldResource.id,
 			name: formData.get('name')!.toString(),
 			resourceType: oldResource.resourceType,

--- a/src/features/homebrew/editor/components/sections/AbilityBonusesSection.ts
+++ b/src/features/homebrew/editor/components/sections/AbilityBonusesSection.ts
@@ -1,6 +1,7 @@
 import { AbilityBonus } from '../../../../../types/domain/helpers/AbilityBonus.js';
 import { BaseResource } from '../../../../../types/domain/wrappers/BaseResource.js';
 import { AbilityBonusRecord } from '../../../../../types/storage/helpers/AbilityBonusRecord.js';
+import { HOMEBREW_RESOURCE_RECORD_VERSION } from '../../../../../types/storage/wrappers/BaseResourceRecord.js';
 import { abilityScoreRepository } from '../../../../../wiring/dependencies.js';
 import {
 	getNumberInputWithLabel,
@@ -95,6 +96,7 @@ export class AbilityBonusesSection extends HTMLElement {
 
 			const abilityBonus: AbilityBonusRecord = {
 				ability_score: {
+					version: HOMEBREW_RESOURCE_RECORD_VERSION,
 					id: abilityScore.index,
 					name: abilityScore.name,
 					resourceType: 'ability-scores',

--- a/src/features/homebrew/editor/components/sections/ChoiceOptionElement.ts
+++ b/src/features/homebrew/editor/components/sections/ChoiceOptionElement.ts
@@ -1,7 +1,10 @@
 import { BaseResource } from '../../../../../types/domain/wrappers/BaseResource.js';
 import { ResourceList } from '../../../../../types/domain/wrappers/ResourceList.js';
 import { OptionRecord } from '../../../../../types/storage/helpers/ChoiceRecord.js';
-import { BaseResourceRecord } from '../../../../../types/storage/wrappers/BaseResourceRecord.js';
+import {
+	BaseResourceRecord,
+	HOMEBREW_RESOURCE_RECORD_VERSION,
+} from '../../../../../types/storage/wrappers/BaseResourceRecord.js';
 import {
 	getEmptyOption,
 	populateSelectWithApiObjects,
@@ -71,6 +74,7 @@ export class ChoiceOptionElement extends HTMLElement {
 	 */
 	getValue(): OptionRecord {
 		const item: BaseResourceRecord = {
+			version: HOMEBREW_RESOURCE_RECORD_VERSION,
 			id: this.select.value,
 			name: this.select.options[this.select.selectedIndex].text,
 			resourceType: '',

--- a/src/features/homebrew/editor/components/sections/ObjectSelect.ts
+++ b/src/features/homebrew/editor/components/sections/ObjectSelect.ts
@@ -1,6 +1,9 @@
 import { BaseResource } from '../../../../../types/domain/wrappers/BaseResource.js';
 import { ResourceList } from '../../../../../types/domain/wrappers/ResourceList.js';
-import { BaseResourceRecord } from '../../../../../types/storage/wrappers/BaseResourceRecord.js';
+import {
+	BaseResourceRecord,
+	HOMEBREW_RESOURCE_RECORD_VERSION,
+} from '../../../../../types/storage/wrappers/BaseResourceRecord.js';
 import {
 	getEmptyOption,
 	populateSelectWithApiObjects,
@@ -70,6 +73,7 @@ export class ObjectSelect extends HTMLElement {
 	 */
 	getValue(): BaseResourceRecord {
 		return {
+			version: HOMEBREW_RESOURCE_RECORD_VERSION,
 			id: this.select.value,
 			name: this.select.options[this.select.selectedIndex].text,
 			resourceType: '',

--- a/src/features/homebrew/manager/components/buttons/NewHomebrewButton.ts
+++ b/src/features/homebrew/manager/components/buttons/NewHomebrewButton.ts
@@ -1,4 +1,7 @@
-import { BaseResourceRecord } from '../../../../../types/storage/wrappers/BaseResourceRecord.js';
+import {
+	BaseResourceRecord,
+	HOMEBREW_RESOURCE_RECORD_VERSION,
+} from '../../../../../types/storage/wrappers/BaseResourceRecord.js';
 import { homebrewRepository } from '../../../../../wiring/dependencies.js';
 
 /**
@@ -65,6 +68,7 @@ export class NewHomebrewButton extends HTMLButtonElement {
 	 */
 	handleClick(): void {
 		const newHomebrewResource: BaseResourceRecord = {
+			version: HOMEBREW_RESOURCE_RECORD_VERSION,
 			id: self.crypto.randomUUID(),
 			name: 'New Custom Object',
 			resourceType: this.apiCategoryName!,

--- a/src/features/homebrew/manager/components/dialogs/HomebrewImportDialog.ts
+++ b/src/features/homebrew/manager/components/dialogs/HomebrewImportDialog.ts
@@ -1,4 +1,4 @@
-import { BaseResourceRecord } from '../../../../../types/storage/wrappers/BaseResourceRecord.js';
+import { upgradeHomebrewResource } from '../../../../../utils/resourceRecordUpgrader.js';
 import { homebrewRepository } from '../../../../../wiring/dependencies.js';
 
 /**
@@ -183,9 +183,10 @@ export class HomebrewImportDialog extends HTMLDialogElement {
 	 */
 	handleImportButtonClick(): void {
 		// Create a new Homebrew from the JSON data.
-		const baseResourceRecord = JSON.parse(
-			this.previewTextarea.value,
-		) as BaseResourceRecord;
+		const baseResourceRecordJson = JSON.parse(this.previewTextarea.value);
+
+		const baseResourceRecord = upgradeHomebrewResource(baseResourceRecordJson);
+
 		const existingHomebrewResource = homebrewRepository.get(
 			baseResourceRecord.id,
 		);

--- a/src/types/storage/wrappers/BaseResourceRecord.ts
+++ b/src/types/storage/wrappers/BaseResourceRecord.ts
@@ -1,9 +1,21 @@
 /**
+ * Current version number for homebrew resource records.
+ * Increment this number whenever the BaseResourceRecord interface has breaking changes.
+ */
+export const HOMEBREW_RESOURCE_RECORD_VERSION = 1;
+
+/**
  * Base interface for all D&D 5e homebrew resource records.
  * Provides common properties shared by all game resources like classes, races, spells, etc.
  * Only used for storage.
  */
 export interface BaseResourceRecord {
+	/**
+	 * Version number for the resource record.
+	 * Used for migration and compatibility checks.
+	 */
+	version: number;
+
 	/**
 	 * Unique identifier for the resource.
 	 * UUID.

--- a/src/utils/resourceRecordUpgrader.ts
+++ b/src/utils/resourceRecordUpgrader.ts
@@ -1,0 +1,65 @@
+import {
+	BaseResourceRecord,
+	HOMEBREW_RESOURCE_RECORD_VERSION,
+} from '../types/storage/wrappers/BaseResourceRecord.js';
+
+/**
+ * Upgrades all homebrew resources in localStorage to the latest version.
+ */
+export function upgradeHomebrewResources(): void {
+	Object.keys(localStorage).forEach((key) => {
+		if (key.startsWith('homebrew_')) {
+			const item = localStorage.getItem(key);
+			if (item) {
+				try {
+					const parsed = JSON.parse(item);
+					if (
+						parsed.version === undefined ||
+						parsed.version < HOMEBREW_RESOURCE_RECORD_VERSION
+					) {
+						const updated = upgradeHomebrewResource(parsed);
+						localStorage.setItem(key, JSON.stringify(updated));
+					}
+				} catch (error) {
+					console.error(`Error parsing ${key}:`, error);
+				}
+			}
+		}
+	});
+}
+
+/**
+ * Upgrades a homebrew resource to the latest version.
+ * @param resource The resource object to upgrade.
+ * @returns The upgraded resource object.
+ */
+export function upgradeHomebrewResource(resource: any): BaseResourceRecord {
+	// v0 -> v1: Rename "index" to "id".
+	if (resource.version === undefined) {
+		resource.version = 1;
+		resource = renameIndexToId(resource);
+	}
+
+	return resource;
+}
+
+/**
+ * Recursively renames "index" to "id" in any object or array.
+ * @param obj The object to rename keys in.
+ * @returns The object with renamed keys.
+ */
+function renameIndexToId(obj: any): any {
+	if (Array.isArray(obj)) {
+		return obj.map(renameIndexToId);
+	} else if (obj && typeof obj === 'object') {
+		const newObj: any = {};
+		for (const key in obj) {
+			if (Object.prototype.hasOwnProperty.call(obj, key)) {
+				const newKey = key === 'index' ? 'id' : key;
+				newObj[newKey] = renameIndexToId(obj[key]);
+			}
+		}
+		return newObj;
+	}
+	return obj;
+}

--- a/src/utils/siteStartupCleanup.ts
+++ b/src/utils/siteStartupCleanup.ts
@@ -1,3 +1,5 @@
+import { upgradeHomebrewResources } from './resourceRecordUpgrader.js';
+
 /**
  * Performs cleanup tasks on site load, such as removing deprecated localStorage items.
  * Extend this function with additional cleanup logic as needed.
@@ -42,39 +44,8 @@ function siteStartupCleanup(): void {
 		}
 	}
 
-	// v0.3.3 -> v0.4.0: rename "index" to "id" in homebrew resources.
-
-	// Recursively rename "index" to "id" in any object or array
-	function renameIndexToId(obj: any): any {
-		if (Array.isArray(obj)) {
-			return obj.map(renameIndexToId);
-		} else if (obj && typeof obj === 'object') {
-			const newObj: any = {};
-			for (const key in obj) {
-				if (Object.prototype.hasOwnProperty.call(obj, key)) {
-					const newKey = key === 'index' ? 'id' : key;
-					newObj[newKey] = renameIndexToId(obj[key]);
-				}
-			}
-			return newObj;
-		}
-		return obj;
-	}
-
-	Object.keys(localStorage).forEach((key) => {
-		if (key.startsWith('homebrew_')) {
-			const item = localStorage.getItem(key);
-			if (item) {
-				try {
-					const parsed = JSON.parse(item);
-					const updated = renameIndexToId(parsed);
-					localStorage.setItem(key, JSON.stringify(updated));
-				} catch (error) {
-					console.error(`Error parsing ${key}:`, error);
-				}
-			}
-		}
-	});
+	// Upgrade existing homebrew resources to the latest version.
+	upgradeHomebrewResources();
 }
 
 // Run cleanup immediately on page load.


### PR DESCRIPTION
## Summary

Add a versioning number to homebrew resources. This way, we can keep control over breaking changes without having to rely on dates and such.

## Related issue

No related issue.

## Checklist

- [x] I updated documentation (README / docs) if needed
- [x] This change is backwards compatible (or explain breaking changes)

## Notes for reviewers
No notes.
