### PR TITLE
chore: add copilot config

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,54 @@
+# Copilot Instructions for AI Coding Agents
+
+## Project Overview
+
+- **DnD Character Manager** is a local-first, privacy-focused web app for managing D&D 5e characters, supporting both official and homebrew content.
+- All data is stored in the browser (`localStorage`) for privacy and offline use. No server-side storage or user authentication.
+- The app is optimized for fast, in-session access to character data, with features for homebrew, import/export, and extensibility.
+
+## Architecture & Data Flow
+
+- **Domain Model:**
+  - `src/types/PlayerCharacter.ts` is the canonical character model. All character data flows through this class.
+  - `src/store/PlayerCharacterBank.ts` manages all characters (active/inactive), persisting directly to `localStorage` (exception to the rule below).
+- **Persistence:**
+  - All persistent data (except `PlayerCharacterBank`) must use `LocalStorageService` (`src/services/LocalStorageService.ts`). Never access `localStorage` directly elsewhere.
+- **Repositories:**
+  - `src/repositories/` contains resource repositories (e.g., `ClassRepository`, `FeatureRepository`, `HomebrewRepository`).
+  - All repositories must check homebrew (via `HomebrewRepository`) before falling back to SRD (official) data.
+  - Homebrew data is always stored with a `homebrew_` prefix to avoid collisions.
+- **API Integration:**
+  - `src/services/SrdApiService.ts` fetches official D&D 5e data from the public SRD API, with caching via `CacheService`.
+  - All API and storage data is mapped to domain models using mappers in `src/mappers/`.
+- **Dependency Injection:**
+  - All services, repositories, and mappers are instantiated and exported from `src/wiring/dependencies.ts` for DI and testability.
+
+## Developer Workflows
+
+- **Install dependencies:** `npm install` (Node) and `bundle install` (Ruby/Jekyll)
+- **Dev Server:** `npm run dev` (watches TS, static, and runs Jekyll locally)
+- **Build:** `npm run build` (TypeScript → JS, static assets, Jekyll site)
+- **Format:** `npm run format:write` (Prettier; pre-commit hook auto-formats staged files)
+- **Clean:** `npm run clean` (removes build artifacts)
+- **No formal test suite** (as of this writing)
+
+## Project Conventions & Patterns
+
+- **Persistence:** Use `LocalStorageService` for all new persistent features (except `PlayerCharacterBank`).
+- **Homebrew Precedence:** Always check homebrew data before SRD/API data in repositories.
+- **Import/Export:** All import/export is JSON-based. Example: serialize a `PlayerCharacter` to JSON for export.
+- **Dependency Injection:** Register all new services, repositories, and mappers in `src/wiring/dependencies.ts`.
+- **No authentication:** All data is local to the browser; do not add user auth.
+- **Commit messages:** Use [Conventional Commits](https://www.conventionalcommits.org/).
+
+## Key Files/Directories
+
+- `src/types/PlayerCharacter.ts` — main character model
+- `src/store/PlayerCharacterBank.ts` — manages all characters
+- `src/services/LocalStorageService.ts` — storage abstraction
+- `src/repositories/` — resource repositories
+- `src/wiring/dependencies.ts` — dependency injection and wiring
+
+---
+
+If any conventions or workflows are unclear, please ask for clarification or check the README or `docs/CONTRIBUTING.md`.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -45,6 +45,8 @@ Thanks for wanting to contribute! This document explains the process for contrib
 - Create a pull request and follow the instructions provided by the template.
 - Link issues with `Closes #<issue>` when the PR resolves an issue.
 - Ensure any automated checks pass on your branch.
+- Your PR will be reviewed and changes may be requested.
+  - For more information, see [Review & merging](#review--merging).
 - All PRs will be squashed and merged on completion.
 
 ## Code style, formatting, & linters
@@ -119,6 +121,11 @@ BREAKING CHANGE: {website}/homebrew is no longer available, use {website}/homebr
 ## Review & merging
 
 - PRs will be reviewed by maintainers and assigned reviewers automatically via CODEOWNERS.
+- GitHub Copilot will also be assigned as a reviewer automatically.
+  - Copilot can NOT approve a PR.
+  - Suggestions by Copilot MAY be applied if they are valid.
+  - If you are not sure wether a Copilot suggestion is valid, wait for a code owner to validate the suggestion and to give further instruction.
+  - PRs will ALWAYS be reviewed by an actual person.
 - Maintain a clean commit history if requested (squash or rebase).
 - Merge is done by maintainers once checks pass and approvals are satisfied.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -124,7 +124,7 @@ BREAKING CHANGE: {website}/homebrew is no longer available, use {website}/homebr
 - GitHub Copilot will also be assigned as a reviewer automatically.
   - Copilot can NOT approve a PR.
   - Suggestions by Copilot MAY be applied if they are valid.
-  - If you are not sure wether a Copilot suggestion is valid, wait for a code owner to validate the suggestion and to give further instruction.
+  - If you are not sure whether a Copilot suggestion is valid, wait for a code owner to validate the suggestion and to give further instruction.
   - PRs will ALWAYS be reviewed by an actual person.
 - Maintain a clean commit history if requested (squash or rebase).
 - Merge is done by maintainers once checks pass and approvals are satisfied.


### PR DESCRIPTION
## Summary

Add a configuration file for GitHub Copilot to use when picking up tasks in the repository. This helps us by making our AI coding agent be more context aware so it better understands the features and inner workings of the project.

## Related issue
No issue.

## Checklist
- [x] I updated documentation (README / docs) if needed
- [x] This change is backwards compatible (or explain breaking changes)

## Notes for reviewers
This file will need to be updated if there's ever a change in approach to certain problems.
