### PR TITLE
fix: no longer show duplicate subclass features in class features

### DIFF
--- a/src/features/character/viewer/class-features/components/ClassFeaturesDisplay.ts
+++ b/src/features/character/viewer/class-features/components/ClassFeaturesDisplay.ts
@@ -211,7 +211,11 @@ export class ClassFeaturesDisplay extends HTMLDetailsElement {
 			const feature = (await featureRepository.getAsync(
 				featureBaseResource.index,
 			))!;
-			fragment.appendChild(await this.getClassFeatureSection(feature));
+
+			// Exclude subclass features.
+			if (!feature.subclass) {
+				fragment.appendChild(await this.getClassFeatureSection(feature));
+			}
 		}
 
 		// If a subclass is chosen, display the features the subclass gets for the given level.


### PR DESCRIPTION
## Summary
Bugfix for showing subclass features for classes regardless of chosen subclass.

## Related issue
No issue.

## Checklist
- [x] I updated documentation (README / docs) if needed
- [x] This change is backwards compatible (or explain breaking changes)

## Notes for reviewers
No notes.
