### PR TITLE
fix: save homebrew race without subraces

### DIFF
--- a/src/features/homebrew/editor/components/forms/RaceForm.ts
+++ b/src/features/homebrew/editor/components/forms/RaceForm.ts
@@ -21,7 +21,6 @@ export class RaceForm extends HomebrewBaseForm {
 	traitsSection?: RaceTraitsSection;
 	languagesSection?: LinkedObjectsSection;
 	languageOptionsSection?: ChoiceSection;
-	subracesSection?: LinkedObjectsSection;
 
 	/**
 	 * Creates an instance of RaceForm.
@@ -157,7 +156,6 @@ export class RaceForm extends HomebrewBaseForm {
 			languages: this.languagesSection!.getValue(),
 			language_options: this.languageOptionsSection!.getValue(),
 			language_desc: formData.get('language_desc')!.toString(),
-			subraces: this.subracesSection!.getValue(),
 		};
 	}
 }

--- a/src/mappers/record/RaceRecordToDomainMapper.ts
+++ b/src/mappers/record/RaceRecordToDomainMapper.ts
@@ -62,10 +62,7 @@ export class RaceRecordToDomainMapper implements IMapper<RaceRecord, Race> {
 				: undefined,
 			language_desc: source.language_desc,
 			traits: source.traits?.map(this.mapTraits) ?? [],
-			subraces:
-				source.subraces?.map((subrace) =>
-					this.baseResourceMapper.map(subrace),
-				) ?? [],
+			subraces: [],
 		};
 	}
 

--- a/src/types/storage/resources/RaceRecord.ts
+++ b/src/types/storage/resources/RaceRecord.ts
@@ -52,11 +52,6 @@ export interface RaceRecord extends BaseResourceRecord {
 	 * A list of traits the race has.
 	 */
 	traits: RaceTraitRecord[];
-
-	/**
-	 * A list of subraces the race has, if any.
-	 */
-	subraces: BaseResourceRecord[];
 }
 
 export interface RaceTraitRecord {


### PR DESCRIPTION
## Summary
Fix where saving races was impossible due to a bug regarding saving subraces. Since we do not support homebrew subraces yet, we can safely remove this.

## Related issue
No related issue.

## Checklist
- [x] I updated documentation (README / docs) if needed
- [x] This change is backwards compatible (or explain breaking changes)

## Notes for reviewers
No notes.
